### PR TITLE
updating curly braces to square braces for compatibility with PHP 7.x

### DIFF
--- a/src/CJSON.php
+++ b/src/CJSON.php
@@ -125,7 +125,7 @@ class CJSON
                  */
                 for ($c = 0; $c < $strlen_var; ++$c) {
 
-                    $ord_var_c = ord($var{$c});
+                    $ord_var_c = ord($var[$c]);
 
                     switch (true) {
                         case $ord_var_c == 0x08:
@@ -148,18 +148,18 @@ class CJSON
                         case $ord_var_c == 0x2F:
                         case $ord_var_c == 0x5C:
                             // double quote, slash, slosh
-                            $ascii .= '\\' . $var{$c};
+                            $ascii .= '\\' . $var[$c];
                             break;
 
                         case (($ord_var_c >= 0x20) && ($ord_var_c <= 0x7F)):
                             // characters U-00000000 - U-0000007F (same as ASCII)
-                            $ascii .= $var{$c};
+                            $ascii .= $var[$c];
                             break;
 
                         case (($ord_var_c & 0xE0) == 0xC0):
                             // characters U-00000080 - U-000007FF, mask 110XXXXX
                             // see http://www.cl.cam.ac.uk/~mgk25/unicode.html#utf-8
-                            $char = pack('C*', $ord_var_c, ord($var{$c + 1}));
+                            $char = pack('C*', $ord_var_c, ord($var[$c + 1]));
                             $c += 1;
                             $utf16 = self::utf8ToUTF16BE($char);
                             $ascii .= sprintf('\u%04s', bin2hex($utf16));
@@ -169,8 +169,8 @@ class CJSON
                             // characters U-00000800 - U-0000FFFF, mask 1110XXXX
                             // see http://www.cl.cam.ac.uk/~mgk25/unicode.html#utf-8
                             $char = pack('C*', $ord_var_c,
-                                ord($var{$c + 1}),
-                                ord($var{$c + 2}));
+                                ord($var[$c + 1]),
+                                ord($var[$c + 2]));
                             $c += 2;
                             $utf16 = self::utf8ToUTF16BE($char);
                             $ascii .= sprintf('\u%04s', bin2hex($utf16));
@@ -180,9 +180,9 @@ class CJSON
                             // characters U-00010000 - U-001FFFFF, mask 11110XXX
                             // see http://www.cl.cam.ac.uk/~mgk25/unicode.html#utf-8
                             $char = pack('C*', $ord_var_c,
-                                ord($var{$c + 1}),
-                                ord($var{$c + 2}),
-                                ord($var{$c + 3}));
+                                ord($var[$c + 1]),
+                                ord($var[$c + 2]),
+                                ord($var[$c + 3]));
                             $c += 3;
                             $utf16 = self::utf8ToUTF16BE($char);
                             $ascii .= sprintf('\u%04s', bin2hex($utf16));
@@ -192,10 +192,10 @@ class CJSON
                             // characters U-00200000 - U-03FFFFFF, mask 111110XX
                             // see http://www.cl.cam.ac.uk/~mgk25/unicode.html#utf-8
                             $char = pack('C*', $ord_var_c,
-                                ord($var{$c + 1}),
-                                ord($var{$c + 2}),
-                                ord($var{$c + 3}),
-                                ord($var{$c + 4}));
+                                ord($var[$c + 1]),
+                                ord($var[$c + 2]),
+                                ord($var[$c + 3]),
+                                ord($var[$c + 4]));
                             $c += 4;
                             $utf16 = self::utf8ToUTF16BE($char);
                             $ascii .= sprintf('\u%04s', bin2hex($utf16));
@@ -205,11 +205,11 @@ class CJSON
                             // characters U-04000000 - U-7FFFFFFF, mask 1111110X
                             // see http://www.cl.cam.ac.uk/~mgk25/unicode.html#utf-8
                             $char = pack('C*', $ord_var_c,
-                                ord($var{$c + 1}),
-                                ord($var{$c + 2}),
-                                ord($var{$c + 3}),
-                                ord($var{$c + 4}),
-                                ord($var{$c + 5}));
+                                ord($var[$c + 1]),
+                                ord($var[$c + 2]),
+                                ord($var[$c + 3]),
+                                ord($var[$c + 4]),
+                                ord($var[$c + 5]));
                             $c += 5;
                             $utf16 = self::utf8ToUTF16BE($char);
                             $ascii .= sprintf('\u%04s', bin2hex($utf16));
@@ -365,7 +365,7 @@ class CJSON
                     for ($c = 0; $c < $strlen_chrs; ++$c) {
 
                         $substr_chrs_c_2 = substr($chrs, $c, 2);
-                        $ord_chrs_c = ord($chrs{$c});
+                        $ord_chrs_c = ord($chrs[$c]);
 
                         switch (true) {
                             case $substr_chrs_c_2 == '\b':
@@ -395,11 +395,11 @@ class CJSON
                             case $substr_chrs_c_2 == '\\/':
                                 if (($delim == '"' && $substr_chrs_c_2 != '\\\'') ||
                                     ($delim == "'" && $substr_chrs_c_2 != '\\"')) {
-                                    $utf8 .= $chrs{++$c};
+                                    $utf8 .= $chrs[++$c];
                                 }
                                 break;
 
-                            case preg_match('/\\\u[0-9A-F]{4}/i', substr($chrs, $c, 6)):
+                            case preg_match('/\\\u[0-9A-F][4]/i', substr($chrs, $c, 6)):
                                 // single, escaped unicode character
                                 $utf16 = chr(hexdec(substr($chrs, ($c + 2), 2)))
                                     . chr(hexdec(substr($chrs, ($c + 4), 2)));
@@ -408,7 +408,7 @@ class CJSON
                                 break;
 
                             case ($ord_chrs_c >= 0x20) && ($ord_chrs_c <= 0x7F):
-                                $utf8 .= $chrs{$c};
+                                $utf8 .= $chrs[$c];
                                 break;
 
                             case ($ord_chrs_c & 0xE0) == 0xC0:
@@ -455,7 +455,7 @@ class CJSON
                 } elseif (preg_match('/^\[.*\]$/s', $str) || preg_match('/^\{.*\}$/s', $str)) {
                     // array, or object notation
 
-                    if ($str{0} == '[') {
+                    if ($str[0] == '[') {
                         $stk = array(self::JSON_IN_ARR);
                         $arr = array();
                     } else {
@@ -483,7 +483,7 @@ class CJSON
                         }
                     }
 
-                    //print("\nparsing {$chrs}\n");
+                    //print("\nparsing [$chrs]\n");
 
                     $strlen_chrs = strlen($chrs);
 
@@ -492,12 +492,12 @@ class CJSON
                         $top = end($stk);
                         $substr_chrs_c_2 = substr($chrs, $c, 2);
 
-                        if (($c == $strlen_chrs) || (($chrs{$c} == ',') && ($top['what'] == self::JSON_SLICE))) {
+                        if (($c == $strlen_chrs) || (($chrs[$c] == ',') && ($top['what'] == self::JSON_SLICE))) {
                             // found a comma that is not inside a string, array, etc.,
                             // OR we've reached the end of the character list
                             $slice = substr($chrs, $top['where'], ($c - $top['where']));
                             $stk[] = array('what' => self::JSON_SLICE, 'where' => ($c + 1), 'delim' => false);
-                            //print("Found split at {$c}: ".substr($chrs, $top['where'], (1 + $c - $top['where']))."\n");
+                            //print("Found split at [$c]: ".substr($chrs, $top['where'], (1 + $c - $top['where']))."\n");
 
                             if (reset($stk) == self::JSON_IN_ARR) {
                                 // we are in an array, so just push an element onto the stack
@@ -532,47 +532,47 @@ class CJSON
 
                             }
 
-                        } elseif ((($chrs{$c} == '"') || ($chrs{$c} == "'")) && ($top['what'] != self::JSON_IN_STR)) {
+                        } elseif ((($chrs[$c] == '"') || ($chrs[$c] == "'")) && ($top['what'] != self::JSON_IN_STR)) {
                             // found a quote, and we are not inside a string
-                            $stk[] = array('what' => self::JSON_IN_STR, 'where' => $c, 'delim' => $chrs{$c});
-                            //print("Found start of string at {$c}\n");
+                            $stk[] = array('what' => self::JSON_IN_STR, 'where' => $c, 'delim' => $chrs[$c]);
+                            //print("Found start of string at [$c]\n");
 
-                        } elseif (($chrs{$c} == $top['delim']) &&
+                        } elseif (($chrs[$c] == $top['delim']) &&
                             ($top['what'] == self::JSON_IN_STR) &&
-                            (($chrs{$c - 1} != "\\") ||
-                                ($chrs{$c - 1} == "\\" && $chrs{$c - 2} == "\\"))) {
+                            (($chrs[$c - 1] != "\\") ||
+                                ($chrs[$c - 1] == "\\" && $chrs[$c - 2] == "\\"))) {
                             // found a quote, we're in a string, and it's not escaped
                             array_pop($stk);
-                            //print("Found end of string at {$c}: ".substr($chrs, $top['where'], (1 + 1 + $c - $top['where']))."\n");
+                            //print("Found end of string at [$c]: ".substr($chrs, $top['where'], (1 + 1 + $c - $top['where']))."\n");
 
-                        } elseif (($chrs{$c} == '[') &&
+                        } elseif (($chrs[$c] == '[') &&
                             in_array($top['what'], array(self::JSON_SLICE, self::JSON_IN_ARR, self::JSON_IN_OBJ))) {
                             // found a left-bracket, and we are in an array, object, or slice
                             $stk[] = array('what' => self::JSON_IN_ARR, 'where' => $c, 'delim' => false);
-                            //print("Found start of array at {$c}\n");
+                            //print("Found start of array at [$c]\n");
 
-                        } elseif (($chrs{$c} == ']') && ($top['what'] == self::JSON_IN_ARR)) {
+                        } elseif (($chrs[$c] == ']') && ($top['what'] == self::JSON_IN_ARR)) {
                             // found a right-bracket, and we're in an array
                             array_pop($stk);
-                            //print("Found end of array at {$c}: ".substr($chrs, $top['where'], (1 + $c - $top['where']))."\n");
+                            //print("Found end of array at [$c]: ".substr($chrs, $top['where'], (1 + $c - $top['where']))."\n");
 
-                        } elseif (($chrs{$c} == '{') &&
+                        } elseif (($chrs[$c] == '{') &&
                             in_array($top['what'], array(self::JSON_SLICE, self::JSON_IN_ARR, self::JSON_IN_OBJ))) {
                             // found a left-brace, and we are in an array, object, or slice
                             $stk[] = array('what' => self::JSON_IN_OBJ, 'where' => $c, 'delim' => false);
-                            //print("Found start of object at {$c}\n");
+                            //print("Found start of object at [$c]\n");
 
-                        } elseif (($chrs{$c} == '}') && ($top['what'] == self::JSON_IN_OBJ)) {
+                        } elseif (($chrs[$c] == '}') && ($top['what'] == self::JSON_IN_OBJ)) {
                             // found a right-brace, and we're in an object
                             array_pop($stk);
-                            //print("Found end of object at {$c}: ".substr($chrs, $top['where'], (1 + $c - $top['where']))."\n");
+                            //print("Found end of object at [$c]: ".substr($chrs, $top['where'], (1 + $c - $top['where']))."\n");
 
                         } elseif (($substr_chrs_c_2 == '/*') &&
                             in_array($top['what'], array(self::JSON_SLICE, self::JSON_IN_ARR, self::JSON_IN_OBJ))) {
                             // found a comment start, and we are in an array, object, or slice
                             $stk[] = array('what' => self::JSON_IN_CMT, 'where' => $c, 'delim' => false);
                             $c++;
-                            //print("Found start of comment at {$c}\n");
+                            //print("Found start of comment at [$c]\n");
 
                         } elseif (($substr_chrs_c_2 == '*/') && ($top['what'] == self::JSON_IN_CMT)) {
                             // found a comment end, and we're in one now
@@ -582,7 +582,7 @@ class CJSON
                             for ($i = $top['where']; $i <= $c; ++$i)
                                 $chrs = substr_replace($chrs, ' ', $i, 1);
 
-                            //print("Found end of comment at {$c}: ".substr($chrs, $top['where'], (1 + $c - $top['where']))."\n");
+                            //print("Found end of comment at [$c]: ".substr($chrs, $top['where'], (1 + $c - $top['where']))."\n");
 
                         }
 


### PR DESCRIPTION
As of PHP 7.4, your code no longer works due to use of `{` for index references rather than the standard `[`; this patch fixes all instances of this issue in within the `src/CJSON.php` file.